### PR TITLE
Replace SSH clone URLs with HTTPS in README

### DIFF
--- a/docs/running_on_testnet.md
+++ b/docs/running_on_testnet.md
@@ -28,7 +28,7 @@ real DAT, they cost you test DAT which you must get from a faucet. Testnet token
 Make sure to install the project dependencies:
 
 ```bash
-git clone git@github.com:vana-com/vana-dlp-template.git
+git clone https://github.com/vana-com/vana-dlp-template.git
 cd vana-dlp-template
 poetry install
 ```
@@ -39,7 +39,7 @@ Configure the environment variables by copying and modifying the `.env.example` 
 Clone and set up the [vana-framework](https://github.com/vana-com/vana-framework) repository to use the `vanacli` to generate keys
 
 ```bash
-git clone git@github.com:vana-com/vana-framework.git
+git clone https://github.com/vana-com/vana-framework.git
 cd vana-framework
 poetry install
 


### PR DESCRIPTION
This PR replaces the SSH clone URLs with HTTPS URLs in two locations within the README file. This change addresses potential permission issues that some users might encounter when trying to clone via SSH without proper key setup.

Changes made:

1. First instance:
   - Replaced: `git clone git@github.com:vana-com/vana-framework.git`
   - With: `git clone https://github.com/vana-com/vana-framework.git`

2. Second instance:
   - Replaced: `git clone git@github.com:vana-com/vana-framework.git`
   - With: `git clone https://github.com/vana-com/vana-framework.git`

These updates ensure that all users can easily clone the repository without encountering SSH-related errors. The HTTPS method is more universally accessible and doesn't require any additional setup for most users.